### PR TITLE
Introduce CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,13 @@ jobs:
     - name: Handle Rust dependencies caching
       uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.target }}
+        key: v2${{ matrix.target }}
 
     - name: Run tests
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace --target ${{ matrix.target }}
+        args: --workspace
 
   test-gleam:
     runs-on: ${{ matrix.os }}
@@ -94,13 +94,12 @@ jobs:
     - name: Handle Rust dependencies caching
       uses: Swatinem/rust-cache@v1
       with:
-        key: ${{ matrix.target }}
+        key: v2${{ matrix.target }}
 
     - name: Run
       uses: actions-rs/cargo@v1
       with:
         command: run
-        args: --target ${{ matrix.target }}
 
     - name: Run gleam tests
       run: gleam test
@@ -109,4 +108,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: templates-${{ matrix.target }}
-        path: target/${{ matrix.target }}/debug/templates
+        path: target/debug/templates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toolchain: [stable]
+        build: [linux-amd64]
+#         build: [linux-amd64, macos, windows]
+        include:
+          - build: linux-amd64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+#           - build: macos
+#             os: macos-latest
+#             target: x86_64-apple-darwin
+#           - build: windows
+#             os: windows-latest
+#             target: x86_64-pc-windows-msvc
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.toolchain }}
+        target: ${{ matrix.target }}
+        profile: minimal
+        override: true
+        default: true
+
+    - name: Handle Rust dependencies caching
+      uses: Swatinem/rust-cache@v1
+      with:
+        key: ${{ matrix.target }}
+
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --target ${{ matrix.target }}
+
+  test-gleam:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        toolchain: [stable]
+        build: [linux-amd64]
+#         build: [linux-amd64, macos, windows]
+        include:
+          - build: linux-amd64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+#           - build: macos
+#             os: macos-latest
+#             target: x86_64-apple-darwin
+#           - build: windows
+#             os: windows-latest
+#             target: x86_64-pc-windows-msvc
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    
+    - name: Install OTP and Gleam
+      uses: erlef/setup-beam@v1.9.0
+      with:
+        otp-version: 23.2
+        gleam-version: 0.19.0-rc1
+        
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.toolchain }}
+        target: ${{ matrix.target }}
+        profile: minimal
+        override: true
+        default: true
+
+    - name: Handle Rust dependencies caching
+      uses: Swatinem/rust-cache@v1
+      with:
+        key: ${{ matrix.target }}
+
+    - name: Run
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: --target ${{ matrix.target }}
+
+    - name: Run gleam tests
+      run: gleam test
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: templates-${{ matrix.target }}
+        path: target/${{ matrix.target }}/debug/templates


### PR DESCRIPTION
(I mainly did this to have an ubuntu build to download from my fork)

I commented out other targets than ubuntu and haven't tested them, ubuntu should be the fastest

Rust cache only cached the dependency download for me for some reason, I don't know rust / cargo well enough to know why. Or maybe I had one bad commit where cache got uploaded for that cargo lock with only downloaded and not compiled deps. No idea, worklfow seems fast enough anyway, cache could be removed if causes problems