### PR TITLE
Improve error handling and reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +275,7 @@ dependencies = [
 name = "templates"
 version = "0.1.0"
 dependencies = [
+ "codespan-reporting",
  "env_logger",
  "insta",
  "log",
@@ -296,6 +307,12 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+codespan-reporting = "0.11.1"
 env_logger = "0.9.0"
 insta = "1.9.0"
 log = "0.4.14"

--- a/src/snapshots/templates__test__error_unknown_keyword.snap
+++ b/src/snapshots/templates__test__error_unknown_keyword.snap
@@ -1,0 +1,15 @@
+---
+source: src/main.rs
+assertion_line: 1064
+expression: "Hello {% wrong %}"
+
+---
+Unknown keyword: wrong
+
+error: 
+  ┌─ -test-:1:10
+  │
+1 │ Hello {% wrong %}
+  │          ^^^^^
+
+

--- a/src/snapshots/templates__test__scan_dot_access.snap
+++ b/src/snapshots/templates__test__scan_dot_access.snap
@@ -1,23 +1,50 @@
 ---
 source: src/main.rs
-assertion_line: 552
+assertion_line: 871
 expression: "Hello{% if user.is_admin %} Admin{% endif %}"
 
 ---
 [
-    Text(
-        "Hello",
+    (
+        Text(
+            "Hello",
+        ),
+        0..5,
     ),
-    OpenStmt,
-    If,
-    Identifier(
-        "user.is_admin",
+    (
+        OpenStmt,
+        5..6,
     ),
-    CloseStmt,
-    Text(
-        " Admin",
+    (
+        If,
+        8..10,
     ),
-    OpenStmt,
-    EndIf,
-    CloseStmt,
+    (
+        Identifier(
+            "user.is_admin",
+        ),
+        11..24,
+    ),
+    (
+        CloseStmt,
+        25..26,
+    ),
+    (
+        Text(
+            " Admin",
+        ),
+        27..33,
+    ),
+    (
+        OpenStmt,
+        33..34,
+    ),
+    (
+        EndIf,
+        36..41,
+    ),
+    (
+        CloseStmt,
+        42..43,
+    ),
 ]

--- a/src/snapshots/templates__test__scan_for_loop.snap
+++ b/src/snapshots/templates__test__scan_for_loop.snap
@@ -1,29 +1,68 @@
 ---
 source: src/main.rs
-assertion_line: 501
+assertion_line: 866
 expression: "Hello {% for item in list %}{{ item }}{% endfor %}"
 
 ---
 [
-    Text(
-        "Hello ",
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
     ),
-    OpenStmt,
-    For,
-    Identifier(
-        "item",
+    (
+        OpenStmt,
+        6..7,
     ),
-    In,
-    Identifier(
-        "list",
+    (
+        For,
+        9..12,
     ),
-    CloseStmt,
-    OpenValue,
-    Identifier(
-        "item",
+    (
+        Identifier(
+            "item",
+        ),
+        13..17,
     ),
-    CloseValue,
-    OpenStmt,
-    EndFor,
-    CloseStmt,
+    (
+        In,
+        18..20,
+    ),
+    (
+        Identifier(
+            "list",
+        ),
+        21..25,
+    ),
+    (
+        CloseStmt,
+        26..27,
+    ),
+    (
+        OpenValue,
+        28..29,
+    ),
+    (
+        Identifier(
+            "item",
+        ),
+        31..35,
+    ),
+    (
+        CloseValue,
+        36..37,
+    ),
+    (
+        OpenStmt,
+        38..39,
+    ),
+    (
+        EndFor,
+        41..47,
+    ),
+    (
+        CloseStmt,
+        48..49,
+    ),
 ]

--- a/src/snapshots/templates__test__scan_identifier.snap
+++ b/src/snapshots/templates__test__scan_identifier.snap
@@ -1,19 +1,34 @@
 ---
 source: src/main.rs
-assertion_line: 293
-expression: "Hello { name }, good to meet you"
+assertion_line: 835
+expression: "Hello {{ name }}, good to meet you"
 
 ---
 [
-    Text(
-        "Hello ",
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
     ),
-    OpenValue,
-    Identifier(
-        "name",
+    (
+        OpenValue,
+        6..7,
     ),
-    CloseValue,
-    Text(
-        ", good to meet you",
+    (
+        Identifier(
+            "name",
+        ),
+        9..13,
+    ),
+    (
+        CloseValue,
+        14..15,
+    ),
+    (
+        Text(
+            ", good to meet you",
+        ),
+        16..33,
     ),
 ]

--- a/src/snapshots/templates__test__scan_if_else_statement.snap
+++ b/src/snapshots/templates__test__scan_if_else_statement.snap
@@ -1,29 +1,68 @@
 ---
 source: src/main.rs
-assertion_line: 444
+assertion_line: 854
 expression: "Hello {% if is_user %}User{% else %}Unknown{% endif %}"
 
 ---
 [
-    Text(
-        "Hello ",
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
     ),
-    OpenStmt,
-    If,
-    Identifier(
-        "is_user",
+    (
+        OpenStmt,
+        6..7,
     ),
-    CloseStmt,
-    Text(
-        "User",
+    (
+        If,
+        9..11,
     ),
-    OpenStmt,
-    Else,
-    CloseStmt,
-    Text(
-        "Unknown",
+    (
+        Identifier(
+            "is_user",
+        ),
+        12..19,
     ),
-    OpenStmt,
-    EndIf,
-    CloseStmt,
+    (
+        CloseStmt,
+        20..21,
+    ),
+    (
+        Text(
+            "User",
+        ),
+        22..26,
+    ),
+    (
+        OpenStmt,
+        26..27,
+    ),
+    (
+        Else,
+        29..33,
+    ),
+    (
+        CloseStmt,
+        34..35,
+    ),
+    (
+        Text(
+            "Unknown",
+        ),
+        36..43,
+    ),
+    (
+        OpenStmt,
+        43..44,
+    ),
+    (
+        EndIf,
+        46..51,
+    ),
+    (
+        CloseStmt,
+        52..53,
+    ),
 ]

--- a/src/snapshots/templates__test__scan_if_statement.snap
+++ b/src/snapshots/templates__test__scan_if_statement.snap
@@ -1,23 +1,50 @@
 ---
 source: src/main.rs
-assertion_line: 352
+assertion_line: 849
 expression: "Hello {% if is_user %}User{% endif %}"
 
 ---
 [
-    Text(
-        "Hello ",
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
     ),
-    OpenStmt,
-    If,
-    Identifier(
-        "is_user",
+    (
+        OpenStmt,
+        6..7,
     ),
-    CloseStmt,
-    Text(
-        "User",
+    (
+        If,
+        9..11,
     ),
-    OpenStmt,
-    EndIf,
-    CloseStmt,
+    (
+        Identifier(
+            "is_user",
+        ),
+        12..19,
+    ),
+    (
+        CloseStmt,
+        20..21,
+    ),
+    (
+        Text(
+            "User",
+        ),
+        22..26,
+    ),
+    (
+        OpenStmt,
+        26..27,
+    ),
+    (
+        EndIf,
+        29..34,
+    ),
+    (
+        CloseStmt,
+        35..36,
+    ),
 ]

--- a/src/snapshots/templates__test__scan_import.snap
+++ b/src/snapshots/templates__test__scan_import.snap
@@ -1,19 +1,40 @@
 ---
 source: src/main.rs
-assertion_line: 698
+assertion_line: 876
 expression: "{> import user.{User}\n{{ name }}"
 
 ---
 [
-    OpenLine,
-    Import,
-    ImportDetails(
-        "user.{User}",
+    (
+        OpenLine,
+        0..1,
     ),
-    CloseLine,
-    OpenValue,
-    Identifier(
-        "name",
+    (
+        Import,
+        3..9,
     ),
-    CloseValue,
+    (
+        ImportDetails(
+            "user.{User}",
+        ),
+        10..21,
+    ),
+    (
+        CloseLine,
+        21..21,
+    ),
+    (
+        OpenValue,
+        22..23,
+    ),
+    (
+        Identifier(
+            "name",
+        ),
+        25..29,
+    ),
+    (
+        CloseValue,
+        30..31,
+    ),
 ]

--- a/src/snapshots/templates__test__scan_nested_if_statements.snap
+++ b/src/snapshots/templates__test__scan_nested_if_statements.snap
@@ -1,38 +1,98 @@
 ---
 source: src/main.rs
-assertion_line: 471
+assertion_line: 859
 expression: "Hello {% if is_user %}{% if is_admin %}Admin{% else %}User{% endif %}{% endif %}"
 
 ---
 [
-    Text(
-        "Hello ",
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
     ),
-    OpenStmt,
-    If,
-    Identifier(
-        "is_user",
+    (
+        OpenStmt,
+        6..7,
     ),
-    CloseStmt,
-    OpenStmt,
-    If,
-    Identifier(
-        "is_admin",
+    (
+        If,
+        9..11,
     ),
-    CloseStmt,
-    Text(
-        "Admin",
+    (
+        Identifier(
+            "is_user",
+        ),
+        12..19,
     ),
-    OpenStmt,
-    Else,
-    CloseStmt,
-    Text(
-        "User",
+    (
+        CloseStmt,
+        20..21,
     ),
-    OpenStmt,
-    EndIf,
-    CloseStmt,
-    OpenStmt,
-    EndIf,
-    CloseStmt,
+    (
+        OpenStmt,
+        22..23,
+    ),
+    (
+        If,
+        25..27,
+    ),
+    (
+        Identifier(
+            "is_admin",
+        ),
+        28..36,
+    ),
+    (
+        CloseStmt,
+        37..38,
+    ),
+    (
+        Text(
+            "Admin",
+        ),
+        39..44,
+    ),
+    (
+        OpenStmt,
+        44..45,
+    ),
+    (
+        Else,
+        47..51,
+    ),
+    (
+        CloseStmt,
+        52..53,
+    ),
+    (
+        Text(
+            "User",
+        ),
+        54..58,
+    ),
+    (
+        OpenStmt,
+        58..59,
+    ),
+    (
+        EndIf,
+        61..66,
+    ),
+    (
+        CloseStmt,
+        67..68,
+    ),
+    (
+        OpenStmt,
+        69..70,
+    ),
+    (
+        EndIf,
+        72..77,
+    ),
+    (
+        CloseStmt,
+        78..79,
+    ),
 ]

--- a/src/snapshots/templates__test__scan_pure_text.snap
+++ b/src/snapshots/templates__test__scan_pure_text.snap
@@ -1,11 +1,14 @@
 ---
 source: src/main.rs
-assertion_line: 266
+assertion_line: 815
 expression: "Hello name, good to meet you"
 
 ---
 [
-    Text(
-        "Hello name, good to meet you",
+    (
+        Text(
+            "Hello name, good to meet you",
+        ),
+        0..27,
     ),
 ]

--- a/src/snapshots/templates__test__scan_single_parens.snap
+++ b/src/snapshots/templates__test__scan_single_parens.snap
@@ -1,11 +1,14 @@
 ---
 source: src/main.rs
-assertion_line: 313
+assertion_line: 830
 expression: "Hello { name }, good to meet you"
 
 ---
 [
-    Text(
-        "Hello { name }, good to meet you",
+    (
+        Text(
+            "Hello { name }, good to meet you",
+        ),
+        0..31,
     ),
 ]

--- a/src/snapshots/templates__test__scan_two_identifiers.snap
+++ b/src/snapshots/templates__test__scan_two_identifiers.snap
@@ -1,27 +1,54 @@
 ---
 source: src/main.rs
-assertion_line: 298
-expression: "Hello { name }, { adjective } to meet you"
+assertion_line: 840
+expression: "Hello {{ name }}, {{ adjective }} to meet you"
 
 ---
 [
-    Text(
-        "Hello ",
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
     ),
-    OpenValue,
-    Identifier(
-        "name",
+    (
+        OpenValue,
+        6..7,
     ),
-    CloseValue,
-    Text(
-        ", ",
+    (
+        Identifier(
+            "name",
+        ),
+        9..13,
     ),
-    OpenValue,
-    Identifier(
-        "adjective",
+    (
+        CloseValue,
+        14..15,
     ),
-    CloseValue,
-    Text(
-        " to meet you",
+    (
+        Text(
+            ", ",
+        ),
+        16..18,
+    ),
+    (
+        OpenValue,
+        18..19,
+    ),
+    (
+        Identifier(
+            "adjective",
+        ),
+        21..30,
+    ),
+    (
+        CloseValue,
+        31..32,
+    ),
+    (
+        Text(
+            " to meet you",
+        ),
+        33..44,
     ),
 ]

--- a/src/snapshots/templates__test__scan_with.snap
+++ b/src/snapshots/templates__test__scan_with.snap
@@ -1,23 +1,50 @@
 ---
 source: src/main.rs
-assertion_line: 703
+assertion_line: 881
 expression: "{> with user as User\n{{ user }}"
 
 ---
 [
-    OpenLine,
-    With,
-    Identifier(
-        "user",
+    (
+        OpenLine,
+        0..1,
     ),
-    As,
-    Identifier(
-        "User",
+    (
+        With,
+        3..7,
     ),
-    CloseLine,
-    OpenValue,
-    Identifier(
-        "user",
+    (
+        Identifier(
+            "user",
+        ),
+        8..12,
     ),
-    CloseValue,
+    (
+        As,
+        13..15,
+    ),
+    (
+        Identifier(
+            "User",
+        ),
+        16..20,
+    ),
+    (
+        CloseLine,
+        20..20,
+    ),
+    (
+        OpenValue,
+        21..22,
+    ),
+    (
+        Identifier(
+            "user",
+        ),
+        24..28,
+    ),
+    (
+        CloseValue,
+        29..30,
+    ),
 ]


### PR DESCRIPTION
We use codespan_reporting and better error handling to give nicer error
messages to the user for certain situations.

Removes some of the expect() calls which is generally a good thing.