### PR TITLE
Simplify scanning

### DIFF
--- a/src/snapshots/templates__test__error_unexpected_keyword.snap
+++ b/src/snapshots/templates__test__error_unexpected_keyword.snap
@@ -1,0 +1,15 @@
+---
+source: src/main.rs
+assertion_line: 1135
+expression: "Hello {% in %}"
+
+---
+Unexpected keyword: in
+
+error: 
+  ┌─ -test-:1:10
+  │
+1 │ Hello {% in %}
+  │          ^^
+
+

--- a/src/snapshots/templates__test__error_unknown_keyword.snap
+++ b/src/snapshots/templates__test__error_unknown_keyword.snap
@@ -1,10 +1,10 @@
 ---
 source: src/main.rs
-assertion_line: 1064
+assertion_line: 1089
 expression: "Hello {% wrong %}"
 
 ---
-Unknown keyword: wrong
+Unexpected identifier: wrong
 
 error: 
   ┌─ -test-:1:10


### PR DESCRIPTION
Instead of using knowledge of the keywords to guide the scanning we just
scan as many tokens as possible in each block and then let the parsing
error as needed. The scanning was doing too much before. Unfortunately
it cannot become completely stupid (I think) becase we need to
distinguish blocks from plain text so that we can scan the plain text as
single chunks whilst scanning the inside of blocks as keywords &
identifiers for the most part.

I'm not a expert so there might be a better way to approach this.