### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
 
 jobs:
 
@@ -45,7 +48,7 @@ jobs:
     - name: Handle Rust dependencies caching
       uses: Swatinem/rust-cache@v1
       with:
-        key: v2${{ matrix.target }}
+        key: v3${{ matrix.target }}
 
     - name: Run tests
       uses: actions-rs/cargo@v1
@@ -93,7 +96,7 @@ jobs:
     - name: Handle Rust dependencies caching
       uses: Swatinem/rust-cache@v1
       with:
-        key: v2${{ matrix.target }}
+        key: v3${{ matrix.target }}
 
     - name: Run
       uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,17 @@ jobs:
     strategy:
       matrix:
         toolchain: [stable]
-        build: [linux-amd64]
-#         build: [linux-amd64, macos, windows]
+        build: [linux-amd64, macos, windows]
         include:
           - build: linux-amd64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-#           - build: macos
-#             os: macos-latest
-#             target: x86_64-apple-darwin
-#           - build: windows
-#             os: windows-latest
-#             target: x86_64-pc-windows-msvc
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: windows
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
     - name: Checkout repository
@@ -60,17 +59,17 @@ jobs:
       matrix:
         toolchain: [stable]
         build: [linux-amd64]
-#         build: [linux-amd64, macos, windows]
+        # build: [linux-amd64, macos, windows]
         include:
           - build: linux-amd64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-#           - build: macos
-#             os: macos-latest
-#             target: x86_64-apple-darwin
-#           - build: windows
-#             os: windows-latest
-#             target: x86_64-pc-windows-msvc
+          # - build: macos
+          #   os: macos-latest
+          #   target: x86_64-apple-darwin
+          # - build: windows
+          #   os: windows-latest
+          #   target: x86_64-pc-windows-msvc
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  build-release:
+    name: build-release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build:
+          - macos
+          - macos-arm64
+          - windows-64bit
+        toolchain: [stable]
+        include:
+          - build: macos
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - build: macos-arm64
+            os: macos-11
+            target: aarch64-apple-darwin
+          - build: windows-64bit
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
+          override: true
+          default: true
+          profile: minimal
+
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: v1-${{ matrix.target }}
+
+      - name: Build release binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Build archive
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            ARCHIVE="gleam-templates-$VERSION-${{ matrix.build }}.zip"
+            cp "target/release/templates.exe" "templates.exe"
+            7z a "$ARCHIVE" "templates.exe"
+            rm templates.exe
+          else
+            ARCHIVE="gleam-templates-$VERSION-${{ matrix.build }}.tar.gz"
+            cp "target/release/templates" "templates"
+            tar -czvf "$ARCHIVE" "templates"
+            rm templates
+          fi
+          openssl dgst -r -sha256 -out "$ARCHIVE".sha256 "$ARCHIVE"
+          openssl dgst -r -sha512 -out "$ARCHIVE".sha512 "$ARCHIVE"
+          echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
+
+      - name: Upload release archive
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: |
+            ${{ env.ASSET }}
+            ${{ env.ASSET }}.sha256
+            ${{ env.ASSET }}.sha512
+
+  build-release-musl:
+    runs-on: ubuntu-latest
+    container: clux/muslrust:stable
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Link to predefined musl toolchain
+        run: |
+          ln -s /root/.cargo $HOME/.cargo
+          ln -s /root/.rustup $HOME/.rustup
+
+      - name: Handle Rust dependencies caching
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: v1-linux-musl
+
+      - name: Build release binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Build archive
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          ARCHIVE="gleam-templates-$VERSION-linux-amd64.tar.gz"
+          cp "target/x86_64-unknown-linux-musl/release/templates" "templates"
+          tar -czvf "$ARCHIVE" "templates"
+          openssl dgst -r -sha256 -out "$ARCHIVE".sha256 "$ARCHIVE"
+          openssl dgst -r -sha512 -out "$ARCHIVE".sha512 "$ARCHIVE"
+          echo "ASSET=$ARCHIVE" >> $GITHUB_ENV
+
+      - name: Upload release archive
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true
+          files: |
+            ${{ env.ASSET }}
+            ${{ env.ASSET }}.sha256
+            ${{ env.ASSET }}.sha512

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]+.[0-9]+.[0-9]+*"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #3 

When a new tag starting with `v` gets pushed to main branch, this workflow will automatically create a *draft* release that people with repository write access can see on the repository's Releases page. Then for each platform a release build will get uploaded there, together with checksum files. Once the workflow is done you can click the edit button on the release, edit release notes and hit Publish :)

Example release created this way: https://github.com/michallepicki/gleam-templates/releases/tag/v0.3.1-dev (I only tested that the linux binary works - this one thanks to statically linking musl should work on all Linuxes I think, not only latest ubuntu?)

I also enabled the test workflow for other platforms. `test-gleam` could also probably be enabled but when I tried the setup-beam action failed on macos because they don't support it yet, so it would need to be replaced with something else.