### PR TITLE
Introduce syntax for inserting string_builder values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- Added support for '{[ name ]}' syntax to allow for inserting string builder values into the
+  template using the underlying `append_builder` call instead of the `append` functon that we use
+  for strings.
+
+  Thank you to @michallepicki for the suggestion.
+
 ## 0.6.0
 
 - Added support for 'for .. as .. in ..' syntax to allow associating a type with the items in the
   list being iterated.
+
+  Thank you to @lpil for the suggestion.
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,27 @@ Alpha. The error messages are poor and there will be plenty of flaws and oversig
 
 The syntax is inspired by [Jinja](https://jinja.palletsprojects.com/).
 
-### Value
+### String Value
 
-You can use `{{ name }}` syntax to insert the value of name into the rendered template. The
+You can use `{{ name }}` syntax to insert the value of `name` into the rendered template. The
 function generated from the template will have a labelled argument matching the identifier used.
 
 ```jinja
 {{ name }}
+```
+
+### String Builder Value
+
+You can use `{[ name ]}` syntax to insert a string builder value into the rendered template. This
+has the advantage of using
+[string_builder.append_builder](https://hexdocs.pm/gleam_stdlib/gleam/string_builder.html#append_builder)
+in the rendered template and so it more efficient for inserting content that is already in a
+`string_builder`. This can be used to insert content from another template.
+
+The function generated from the template will have a labelled argument matching the identifier used.
+
+```jinja
+{[ name ]}
 ```
 
 ### If

--- a/src/snapshots/templates__test__parse_builder_block.snap
+++ b/src/snapshots/templates__test__parse_builder_block.snap
@@ -1,0 +1,17 @@
+---
+source: src/main.rs
+assertion_line: 1201
+expression: "Hello {[ name ]}, good to meet you"
+
+---
+[
+    Text(
+        "Hello ",
+    ),
+    Builder(
+        "name",
+    ),
+    Text(
+        ", good to meet you",
+    ),
+]

--- a/src/snapshots/templates__test__render_builder_block.snap
+++ b/src/snapshots/templates__test__render_builder_block.snap
@@ -1,0 +1,24 @@
+---
+source: src/main.rs
+assertion_line: 1298
+expression: "Hello {[ name ]}, good to meet you"
+
+---
+import gleam/string_builder.{StringBuilder}
+import gleam/list
+
+
+
+pub fn render_builder(name name) -> StringBuilder {
+    let builder = string_builder.from_string("")
+    let builder = string_builder.append(builder, "Hello ")
+    let builder = string_builder.append_builder(builder, name)
+    let builder = string_builder.append(builder, ", good to meet you")
+
+    builder
+}
+
+pub fn render(name name) -> String {
+    string_builder.to_string(render_builder(name: name))
+}
+

--- a/src/snapshots/templates__test__scan_builder_block.snap
+++ b/src/snapshots/templates__test__scan_builder_block.snap
@@ -1,0 +1,34 @@
+---
+source: src/main.rs
+assertion_line: 1092
+expression: "Hello {[ builder ]}, good to meet you"
+
+---
+[
+    (
+        Text(
+            "Hello ",
+        ),
+        0..6,
+    ),
+    (
+        OpenBuilder,
+        6..7,
+    ),
+    (
+        Identifier(
+            "builder",
+        ),
+        9..16,
+    ),
+    (
+        CloseBuilder,
+        17..18,
+    ),
+    (
+        Text(
+            ", good to meet you",
+        ),
+        19..36,
+    ),
+]

--- a/test/template/builder.gleamx
+++ b/test/template/builder.gleamx
@@ -1,0 +1,1 @@
+Hello {[ name_builder ]}, good to meet you

--- a/test/templates_test.gleam
+++ b/test/templates_test.gleam
@@ -1,3 +1,5 @@
+import gleam/string_builder
+
 import gleeunit
 import gleeunit/should
 
@@ -14,6 +16,7 @@ import template/multiline
 import template/value_in_for_loop
 import template/value_in_if_else
 import template/quote
+import template/builder
 
 import my_user.{User, NamedUser}
 
@@ -40,6 +43,12 @@ pub fn two_identifiers_test() {
 pub fn double_identifier_usage_test() {
   double_identifier_usage.render("Double")
   |> should.equal("Double usage, Double usage\n")
+}
+
+pub fn builder_block_test() {
+  let name_builder = string_builder.from_strings(["Anna", " ", "Bandana"])
+  builder.render(name_builder)
+  |> should.equal("Hello Anna Bandana, good to meet you\n")
 }
 
 pub fn if_statement_test() {


### PR DESCRIPTION
As suggested by @michallepicki in #11.

I've gone with the `{[ name ]}` syntax as I feel that the `{}` are consistent with other parts of the template syntax whilst the `[]` gives an indication of the list type nature of the string_builder. 