### PR TITLE
 Require all parameters to be explicitly declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Breaking change: all parameters to the template must now be declared using the `{> with ... as
+  ...` syntax. The template generation will no longer try to automatically deduce parameters from
+  the template contents. Being explicit allows us to include static content from imported modules
+  without the generation getting confused about what is a parameter and what is an import.
+
 ## 0.7.0
 
 - Added support for '{[ name ]}' syntax to allow for inserting string builder values into the

--- a/README.md
+++ b/README.md
@@ -38,19 +38,32 @@ invalid modules and so the Gleam compiler will pick up further errors.
 
 ## Status
 
-Alpha. The error messages are poor and there will be plenty of flaws and oversights.
+Beta. The project has had some attention and the test coverage is good.
 
 ## Syntax
 
 The syntax is inspired by [Jinja](https://jinja.palletsprojects.com/).
 
+### With
+
+You can use `{>` syntax to add `with` statements to declare parameters and their assoicated types
+for the template and the generated render function. All parameters must be declared with `with`
+statements.
+
+```
+{> with greeting as String
+{> with name as String
+
+{{ greeting }}, {{ name }}
+```
+
 ### String Value
 
-You can use `{{ name }}` syntax to insert the value of `name` into the rendered template. The
-function generated from the template will have a labelled argument matching the identifier used.
+You can use `{{ name }}` syntax to insert the value of `name` into the rendered template.
 
 ```jinja
-{{ name }}
+{> with name as String
+Hello {{ name }}
 ```
 
 ### String Builder Value
@@ -59,11 +72,10 @@ You can use `{[ name ]}` syntax to insert a string builder value into the render
 has the advantage of using
 [string_builder.append_builder](https://hexdocs.pm/gleam_stdlib/gleam/string_builder.html#append_builder)
 in the rendered template and so it more efficient for inserting content that is already in a
-`string_builder`. This can be used to insert content from another template.
-
-The function generated from the template will have a labelled argument matching the identifier used.
+`StringBuilder`. This can be used to insert content from another template.
 
 ```jinja
+{> with name as StringBuilder
 {[ name ]}
 ```
 
@@ -76,6 +88,7 @@ after `if`.
 The `else` is optional.
 
 ```jinja
+{> with is_admin as Bool
 {% if is_admin %}Admin{% else %}User{% endif %}
 ```
 
@@ -86,6 +99,7 @@ function generated from the template will have a labelled argument matching the 
 after `in`.
 
 ```html+jinja
+{> with list as List(String)
 <ul>
 {% for entry in list %}
     <li>{{ entry }}</li>
@@ -97,9 +111,11 @@ Additionally you can use the `as` keyword to associate a type with the items bei
 This is necessary if you're using a complex object.
 
 ```html+jinja
-{> import my_user.{MyUser}
+{> import organisation.{Organisation}
+{> import membership.{Member}
+{> with org as Organisation
 <ul>
-{% for user as MyUser in users %}
+{% for user as Member in organisation.members %}
     <li>{{ user.name }}</li>
 {% endfor %}
 </ul>
@@ -112,21 +128,6 @@ to use with the `with` syntax below to help Gleam check variables used in the te
 
 ```
 {> import my_user.{MyUser}
-```
-
-### With
-
-You can use `{>` syntax to add `with` statements with associate types with variables in the
-template. The type is used for the corresponding argument in the function generated from the
-template. The Gleam compiler can infer simple types like booleans and strings but needs type
-annotations for more complex structures like a custom types.
-
-```
-{> import my_user.{MyUser}
-
-{> with user_record as MyUser
-
-{{ user_record.name }}
 ```
 
 ## Output

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,7 +609,7 @@ fn consume_token(tokens: &mut TokenIter, expected_token: Token) -> Result<(), Pa
         Some((matched_token, range)) => Err(ParserError::UnexpectedToken(
             matched_token.clone(),
             range.clone(),
-            vec![expected_token.clone()],
+            vec![expected_token],
         )),
         None => Err(ParserError::UnexpectedEnd),
     }
@@ -667,9 +667,9 @@ pub fn render({}) -> String {{
     Ok(output)
 }
 
-fn render_lines(
-    iter: &mut NodeIter,
-) -> Result<(String, Vec<String>, Vec<(String, String)>), RenderError> {
+type RenderDetails = (String, Vec<String>, Vec<(String, String)>);
+
+fn render_lines(iter: &mut NodeIter) -> Result<RenderDetails, RenderError> {
     let mut builder_lines = String::new();
     let mut imports = vec![];
 
@@ -742,7 +742,7 @@ fn render_lines(
                 let entry_type = entry_type
                     .as_ref()
                     .map(|value| format!(": {}", value))
-                    .unwrap_or("".to_string());
+                    .unwrap_or_else(|| "".to_string());
 
                 let (loop_lines, _, _) = render_lines(&mut loop_nodes.iter().peekable())?;
                 builder_lines.push_str(&format!(

--- a/src/snapshots/templates__test__error_duplicate_with.snap
+++ b/src/snapshots/templates__test__error_duplicate_with.snap
@@ -1,0 +1,15 @@
+---
+source: src/main.rs
+assertion_line: 1348
+expression: "{> with name as String\n{> with name as String\nHello"
+
+---
+This is declared in more than one 'with' statement: name
+
+error: 
+  ┌─ -test-:2:9
+  │
+2 │ {> with name as String
+  │         ^^^^
+
+

--- a/src/snapshots/templates__test__error_duplicate_with_name.snap
+++ b/src/snapshots/templates__test__error_duplicate_with_name.snap
@@ -1,0 +1,15 @@
+---
+source: src/main.rs
+assertion_line: 1357
+expression: "{> with name as String\n{> with name as String\nHello"
+
+---
+This is declared in more than one 'with' statement: name
+
+error: 
+  ┌─ -test-:2:9
+  │
+2 │ {> with name as String
+  │         ^^^^
+
+

--- a/src/snapshots/templates__test__parse_with.snap
+++ b/src/snapshots/templates__test__parse_with.snap
@@ -1,12 +1,15 @@
 ---
 source: src/main.rs
-assertion_line: 767
+assertion_line: 1189
 expression: "{> with user as User\n{{ user }}"
 
 ---
 [
     With(
-        "user",
+        (
+            "user",
+            8..12,
+        ),
         "User",
     ),
     Identifier(

--- a/src/snapshots/templates__test__render_builder_block.snap
+++ b/src/snapshots/templates__test__render_builder_block.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 1298
-expression: "Hello {[ name ]}, good to meet you"
+assertion_line: 1291
+expression: "{> with name as StringBuilder\nHello {[ name ]}, good to meet you"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(name name) -> StringBuilder {
+pub fn render_builder(name name: StringBuilder) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = string_builder.append_builder(builder, name)
@@ -18,7 +18,7 @@ pub fn render_builder(name name) -> StringBuilder {
     builder
 }
 
-pub fn render(name name) -> String {
+pub fn render(name name: StringBuilder) -> String {
     string_builder.to_string(render_builder(name: name))
 }
 

--- a/src/snapshots/templates__test__render_dot_access.snap
+++ b/src/snapshots/templates__test__render_dot_access.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 761
-expression: "Hello{% if user.is_admin %} Admin{% endif %}"
+assertion_line: 1248
+expression: "{> with user as MyUser\nHello{% if user.is_admin %} Admin{% endif %}"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(user user) -> StringBuilder {
+pub fn render_builder(user user: MyUser) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello")
     let builder = case user.is_admin {
@@ -27,7 +27,7 @@ pub fn render_builder(user user) -> StringBuilder {
     builder
 }
 
-pub fn render(user user) -> String {
+pub fn render(user user: MyUser) -> String {
     string_builder.to_string(render_builder(user: user))
 }
 

--- a/src/snapshots/templates__test__render_empty_if_statement.snap
+++ b/src/snapshots/templates__test__render_empty_if_statement.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 739
-expression: "Hello {% if is_user %}{% endif %}"
+assertion_line: 1207
+expression: "{> with is_user as Bool\nHello {% if is_user %}{% endif %}"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(is_user is_user) -> StringBuilder {
+pub fn render_builder(is_user is_user: Bool) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = case is_user {
@@ -26,7 +26,7 @@ pub fn render_builder(is_user is_user) -> StringBuilder {
     builder
 }
 
-pub fn render(is_user is_user) -> String {
+pub fn render(is_user is_user: Bool) -> String {
     string_builder.to_string(render_builder(is_user: is_user))
 }
 

--- a/src/snapshots/templates__test__render_for_as_loop.snap
+++ b/src/snapshots/templates__test__render_for_as_loop.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 1186
-expression: "Hello,{% for item as Item in list %} to {{ item }} and {% endfor %} everyone else"
+assertion_line: 1240
+expression: "{> with list as List(Item)\nHello,{% for item as Item in list %} to {{ item }} and {% endfor %} everyone else"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(list list) -> StringBuilder {
+pub fn render_builder(list list: List(Item)) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello,")
     let builder = list.fold(list, builder, fn(builder, item: Item) {
@@ -24,7 +24,7 @@ pub fn render_builder(list list) -> StringBuilder {
     builder
 }
 
-pub fn render(list list) -> String {
+pub fn render(list list: List(Item)) -> String {
     string_builder.to_string(render_builder(list: list))
 }
 

--- a/src/snapshots/templates__test__render_for_loop.snap
+++ b/src/snapshots/templates__test__render_for_loop.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 756
-expression: "Hello,{% for item in list %} to {{ item }} and {% endfor %} everyone else"
+assertion_line: 1232
+expression: "{> with list as List(String)\nHello,{% for item in list %} to {{ item }} and {% endfor %} everyone else"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(list list) -> StringBuilder {
+pub fn render_builder(list list: List(String)) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello,")
     let builder = list.fold(list, builder, fn(builder, item) {
@@ -24,7 +24,7 @@ pub fn render_builder(list list) -> StringBuilder {
     builder
 }
 
-pub fn render(list list) -> String {
+pub fn render(list list: List(String)) -> String {
     string_builder.to_string(render_builder(list: list))
 }
 

--- a/src/snapshots/templates__test__render_identifier.snap
+++ b/src/snapshots/templates__test__render_identifier.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 719
-expression: "Hello {{ name }}, good to meet you"
+assertion_line: 1174
+expression: "{> with name as String\nHello {{ name }}, good to meet you"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(name name) -> StringBuilder {
+pub fn render_builder(name name: String) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = string_builder.append(builder, name)
@@ -18,7 +18,7 @@ pub fn render_builder(name name) -> StringBuilder {
     builder
 }
 
-pub fn render(name name) -> String {
+pub fn render(name name: String) -> String {
     string_builder.to_string(render_builder(name: name))
 }
 

--- a/src/snapshots/templates__test__render_if_else_statement.snap
+++ b/src/snapshots/templates__test__render_if_else_statement.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 744
-expression: "Hello {% if is_user %}User{% else %}Unknown{% endif %}"
+assertion_line: 1215
+expression: "{> with is_user as Bool\nHello {% if is_user %}User{% else %}Unknown{% endif %}"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(is_user is_user) -> StringBuilder {
+pub fn render_builder(is_user is_user: Bool) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = case is_user {
@@ -28,7 +28,7 @@ pub fn render_builder(is_user is_user) -> StringBuilder {
     builder
 }
 
-pub fn render(is_user is_user) -> String {
+pub fn render(is_user is_user: Bool) -> String {
     string_builder.to_string(render_builder(is_user: is_user))
 }
 

--- a/src/snapshots/templates__test__render_if_statement.snap
+++ b/src/snapshots/templates__test__render_if_statement.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 734
-expression: "Hello {% if is_user %}User{% endif %}"
+assertion_line: 1199
+expression: "{> with is_user as Bool\nHello {% if is_user %}User{% endif %}"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(is_user is_user) -> StringBuilder {
+pub fn render_builder(is_user is_user: Bool) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = case is_user {
@@ -27,7 +27,7 @@ pub fn render_builder(is_user is_user) -> StringBuilder {
     builder
 }
 
-pub fn render(is_user is_user) -> String {
+pub fn render(is_user is_user: Bool) -> String {
     string_builder.to_string(render_builder(is_user: is_user))
 }
 

--- a/src/snapshots/templates__test__render_import.snap
+++ b/src/snapshots/templates__test__render_import.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 766
-expression: "{> import user.{User}\n{{ name }}"
+assertion_line: 1256
+expression: "{> import user.{User}\n{> with name as String\n{{ name }}"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,14 +9,14 @@ import gleam/list
 
 import user.{User}
 
-pub fn render_builder(name name) -> StringBuilder {
+pub fn render_builder(name name: String) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, name)
 
     builder
 }
 
-pub fn render(name name) -> String {
+pub fn render(name name: String) -> String {
     string_builder.to_string(render_builder(name: name))
 }
 

--- a/src/snapshots/templates__test__render_multiline.snap
+++ b/src/snapshots/templates__test__render_multiline.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 845
-expression: "<ul>\n{% for entry in my_list %}\n    <li>{{ entry }}</li>\n{% endfor %}\n</ul>"
+assertion_line: 1271
+expression: "{> with my_list as List(String)\n<ul>\n{% for entry in my_list %}\n    <li>{{ entry }}</li>\n{% endfor %}\n</ul>"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(my_list my_list) -> StringBuilder {
+pub fn render_builder(my_list my_list: List(String)) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "<ul>
 ")
@@ -28,7 +28,7 @@ pub fn render_builder(my_list my_list) -> StringBuilder {
     builder
 }
 
-pub fn render(my_list my_list) -> String {
+pub fn render(my_list my_list: List(String)) -> String {
     string_builder.to_string(render_builder(my_list: my_list))
 }
 

--- a/src/snapshots/templates__test__render_nested_if_statements.snap
+++ b/src/snapshots/templates__test__render_nested_if_statements.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 749
-expression: "Hello {% if is_user %}{% if is_admin %}Admin{% else %}User{% endif %}{% endif %}"
+assertion_line: 1246
+expression: "{> with is_user as Bool\n{> with is_admin as Bool\nHello {% if is_user %}{% if is_admin %}Admin{% else %}User{% endif %}{% endif %}"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(is_user is_user, is_admin is_admin) -> StringBuilder {
+pub fn render_builder(is_user is_user: Bool, is_admin is_admin: Bool) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = case is_user {
@@ -38,7 +38,7 @@ pub fn render_builder(is_user is_user, is_admin is_admin) -> StringBuilder {
     builder
 }
 
-pub fn render(is_user is_user, is_admin is_admin) -> String {
+pub fn render(is_user is_user: Bool, is_admin is_admin: Bool) -> String {
     string_builder.to_string(render_builder(is_user: is_user, is_admin: is_admin))
 }
 

--- a/src/snapshots/templates__test__render_quotes.snap
+++ b/src/snapshots/templates__test__render_quotes.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 856
-expression: "<div class=\"my-class\">{{ name }}</div>"
+assertion_line: 1283
+expression: "{> with name as String\n<div class=\"my-class\">{{ name }}</div>"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(name name) -> StringBuilder {
+pub fn render_builder(name name: String) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "<div class=\"my-class\">")
     let builder = string_builder.append(builder, name)
@@ -18,7 +18,7 @@ pub fn render_builder(name name) -> StringBuilder {
     builder
 }
 
-pub fn render(name name) -> String {
+pub fn render(name name: String) -> String {
     string_builder.to_string(render_builder(name: name))
 }
 

--- a/src/snapshots/templates__test__render_two_identifiers.snap
+++ b/src/snapshots/templates__test__render_two_identifiers.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 724
-expression: "Hello {{ name }}, {{ adjective }} to meet you"
+assertion_line: 1205
+expression: "{> with name as String\n{> with adjective as String\nHello {{ name }}, {{ adjective }} to meet you"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(name name, adjective adjective) -> StringBuilder {
+pub fn render_builder(name name: String, adjective adjective: String) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, "Hello ")
     let builder = string_builder.append(builder, name)
@@ -20,7 +20,7 @@ pub fn render_builder(name name, adjective adjective) -> StringBuilder {
     builder
 }
 
-pub fn render(name name, adjective adjective) -> String {
+pub fn render(name name: String, adjective adjective: String) -> String {
     string_builder.to_string(render_builder(name: name, adjective: adjective))
 }
 

--- a/src/snapshots/templates__test__repeated_identifier_usage.snap
+++ b/src/snapshots/templates__test__repeated_identifier_usage.snap
@@ -1,7 +1,7 @@
 ---
 source: src/main.rs
-assertion_line: 729
-expression: "{{ name }} usage, {{ name }} usage"
+assertion_line: 1191
+expression: "{> with name as String\n{{ name }} usage, {{ name }} usage"
 
 ---
 import gleam/string_builder.{StringBuilder}
@@ -9,7 +9,7 @@ import gleam/list
 
 
 
-pub fn render_builder(name name) -> StringBuilder {
+pub fn render_builder(name name: String) -> StringBuilder {
     let builder = string_builder.from_string("")
     let builder = string_builder.append(builder, name)
     let builder = string_builder.append(builder, " usage, ")
@@ -19,7 +19,7 @@ pub fn render_builder(name name) -> StringBuilder {
     builder
 }
 
-pub fn render(name name) -> String {
+pub fn render(name name: String) -> String {
     string_builder.to_string(render_builder(name: name))
 }
 

--- a/test/template/builder.gleamx
+++ b/test/template/builder.gleamx
@@ -1,1 +1,2 @@
+{> with name_builder as StringBuilder
 Hello {[ name_builder ]}, good to meet you

--- a/test/template/double_identifier_usage.gleamx
+++ b/test/template/double_identifier_usage.gleamx
@@ -1,1 +1,2 @@
+{> with name as String
 {{ name }} usage, {{ name }} usage

--- a/test/template/for_loop.gleamx
+++ b/test/template/for_loop.gleamx
@@ -1,1 +1,2 @@
+{> with list as List(String)
 Hello,{% for item in list %} to {{ item }} and{% endfor %} everyone else

--- a/test/template/identifier.gleamx
+++ b/test/template/identifier.gleamx
@@ -1,1 +1,2 @@
+{> with name as String
 Hello {{ name }}, good to meet you

--- a/test/template/if_else_statement.gleamx
+++ b/test/template/if_else_statement.gleamx
@@ -1,1 +1,2 @@
+{> with is_user as Bool
 Hello {% if is_user %}User{% else %}Unknown{% endif %}

--- a/test/template/if_statement.gleamx
+++ b/test/template/if_statement.gleamx
@@ -1,1 +1,2 @@
+{> with is_user as Bool
 Hello{% if is_user %} User{% endif %}

--- a/test/template/multiline.gleamx
+++ b/test/template/multiline.gleamx
@@ -1,3 +1,4 @@
+{> with my_list as List(String)
 <h1>My List</h1>
 <ul>
 {% for entry in my_list %}

--- a/test/template/nested_if_statement.gleamx
+++ b/test/template/nested_if_statement.gleamx
@@ -1,1 +1,3 @@
+{> with is_user as Bool
+{> with is_admin as Bool
 Hello{% if is_user %} {% if is_admin %}Admin{% else %}User{% endif %}{% endif %}

--- a/test/template/quote.gleamx
+++ b/test/template/quote.gleamx
@@ -1,1 +1,2 @@
+{> with name as String
 <div class="my-class">{{ name }}</div>

--- a/test/template/two_identifiers.gleamx
+++ b/test/template/two_identifiers.gleamx
@@ -1,1 +1,3 @@
+{> with name as String
+{> with adjective as String
 Hello {{ name }}, {{ adjective }} to meet you

--- a/test/template/value_in_for_loop.gleamx
+++ b/test/template/value_in_for_loop.gleamx
@@ -1,3 +1,5 @@
+{> with my_list as List(String)
+{> with greeting as String
 <h1>My List</h1>
 <ul>
 {% for entry in my_list %}

--- a/test/template/value_in_if_else.gleamx
+++ b/test/template/value_in_if_else.gleamx
@@ -1,1 +1,3 @@
+{> with is_user as Bool
+{> with greeting as String
 {% if is_user %}{{ greeting }} User{% else %}{{ greeting }} Unknown{% endif %}


### PR DESCRIPTION
Using 'with' statements.

Rather than attempting to infer them from the usage in the template
itself. This has been suggested by @lpil and @michallepicki in order to
make it easier to import modules and use them within the templates and
avoid the engine attempting to infer the module name as a parameter or
generally failing in other ways.

There is an error if you declare the same thing twice using 'with'
statements.

This does mean that users need to explicitly declare all the parameters
name and declare types for String and StringBuilder values. We might be
able to remove the {[]} syntax for StringBuilder injection as we'll
already have that information from the 'with' statements.